### PR TITLE
Added nodes with a zero motif-role profile

### DIFF
--- a/pymfinder/pymfinder.py
+++ b/pymfinder/pymfinder.py
@@ -552,7 +552,12 @@ def role_stats(mfinderi,network,stoufferIDs,networktype):
 
     cmfinder.res_tbl_mem_free_single(results)
 
-    for n in roles:
+    nmax=max([max(k[0],k[1]) for k in _network])
+    for n in range(1,nmax+1):
+        try:
+            x = roles[n]
+        except KeyError:
+            roles[n] = {}
         for r in possible_roles:
             try:
                 x = roles[n][r]


### PR DESCRIPTION
motif_roles() returned a dictionary of the different motif-role profiles. However, it excluded species that were not part of any motif (i.e. species with a motif-role profile of zeros). I made a small change in order to fix that!
