### PR TITLE
Update globals.h

### DIFF
--- a/pymfinder/mfinder/globals.h
+++ b/pymfinder/mfinder/globals.h
@@ -67,7 +67,7 @@ extern Res_vec_tbl Roles_res_tbl;
 //final results for role statistics
 extern Role_res *Roles_final_res;
 //Roles members 2 dim array [Role_id][node]
-list **Roles_members;
+extern list **Roles_members;
 
 //Gneralized motifs final res lists
 extern list64 *gmtf_final_res;


### PR DESCRIPTION
Variable should be an 'extern' and not a true global.

This ought to fix the issue arising with failed compilation/installation on macs.